### PR TITLE
Add POST request support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A simple, minimal-dependency HTTP client for Rust. It provides a clean and intui
 ## Features
 
 - Simple and intuitive API
+- GET and POST requests
 - Minimal dependencies
 - Optional HTTPS support via native-tls
 - Optional timeout support
@@ -85,6 +86,15 @@ TINYGET_TIMEOUT=5 cargo run
 ```rust
 let response = tinyget::get("https://httpbin.org/anything")
     .with_header("User-Agent", "tinyget/1.1")
+    .send()?;
+```
+
+### POST Requests
+
+```rust
+let response = tinyget::post("https://httpbin.org/anything")
+    .with_header("Content-Type", "text/plain")
+    .with_body("hello from tinyget")
     .send()?;
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,6 +119,21 @@
 //! # Ok(()) }
 //! ```
 //!
+//! ## POST Requests
+//!
+//! To send a POST request, use [`post`](fn.post.html). Request bodies
+//! can be set with [`with_body`](struct.Request.html#method.with_body).
+//!
+//! ```
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! let response = tinyget::post("http://httpbin.org/anything")
+//!     .with_header("Content-Type", "text/plain")
+//!     .with_body("hello from tinyget")
+//!     .send()?;
+//! assert_eq!(response.status_code, 200);
+//! # Ok(()) }
+//! ```
+//!
 //! ## Timeouts
 //! To avoid timing out, or limit the request's response time, use
 //! `with_timeout(n)` before `send()`. The given value is in seconds.

--- a/src/request.rs
+++ b/src/request.rs
@@ -25,6 +25,8 @@ pub type URL = String;
 pub struct Request {
     pub(crate) host: URL,
     resource: URL,
+    method: String,
+    body: Vec<u8>,
     headers: HashMap<String, String>,
     query: HashMap<String, String>,
     #[cfg(feature = "timeout")]
@@ -44,6 +46,8 @@ impl Request {
         Request {
             host,
             resource,
+            method: "GET".to_string(),
+            body: Vec::new(),
             headers: HashMap::new(),
             query: HashMap::new(),
             #[cfg(feature = "timeout")]
@@ -58,6 +62,18 @@ impl Request {
     /// function to add headers to your requests.
     pub fn with_header<T: Into<String>, U: Into<String>>(mut self, key: T, value: U) -> Request {
         self.headers.insert(key.into(), value.into());
+        self
+    }
+
+    /// Sets the HTTP method for the request.
+    pub fn with_method<T: Into<String>>(mut self, method: T) -> Request {
+        self.method = method.into();
+        self
+    }
+
+    /// Sets the request body.
+    pub fn with_body<T: AsRef<[u8]>>(mut self, body: T) -> Request {
+        self.body = body.as_ref().to_vec();
         self
     }
 
@@ -215,14 +231,28 @@ impl Request {
             }
             format!("{}{}", self.resource, query_string)
         };
-        http += &format!("GET {} HTTP/1.1\r\nHost: {}\r\n", resource, self.host);
+        http += &format!(
+            "{} {} HTTP/1.1\r\nHost: {}\r\n",
+            self.method, resource, self.host
+        );
         // Add other headers
         for (k, v) in &self.headers {
             http += &format!("{}: {}\r\n", k, v);
         }
 
+        if !self.body.is_empty()
+            && !self
+                .headers
+                .keys()
+                .any(|key| key.eq_ignore_ascii_case("content-length"))
+        {
+            http += &format!("Content-Length: {}\r\n", self.body.len());
+        }
+
         http += "\r\n";
-        http.into_bytes()
+        let mut http = http.into_bytes();
+        http.extend_from_slice(&self.body);
+        http
     }
 
     /// Returns the redirected version of this Request, unless an
@@ -308,4 +338,9 @@ fn parse_url(url: URL) -> (bool, URL, URL) {
 /// Alias for [Request::new](struct.Request.html#method.new)
 pub fn get<T: Into<URL>>(url: T) -> Request {
     Request::new(url)
+}
+
+/// Creates a POST request.
+pub fn post<T: Into<URL>>(url: T) -> Request {
+    Request::new(url).with_method("POST")
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -15,7 +15,7 @@ pub fn setup() {
             let server = server.clone();
 
             thread::spawn(move || loop {
-                let request = {
+                let mut request = {
                     if let Ok(request) = server.recv() {
                         request
                     } else {
@@ -41,6 +41,14 @@ pub fn setup() {
 
                     Method::Get if url.starts_with("/query") => {
                         let response = Response::from_string(echo_query_params(&url));
+                        request.respond(response).ok();
+                    }
+
+                    Method::Post if url == "/post" => {
+                        let mut body = String::new();
+                        request.as_reader().read_to_string(&mut body).ok();
+                        let response =
+                            Response::from_string(format!("method: POST\nbody: {}", body));
                         request.respond(response).ok();
                     }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -79,6 +79,13 @@ fn test_get() {
 }
 
 #[test]
+fn test_post() {
+    setup();
+    let body = get_body(tinyget::post(url("/post")).with_body("hello").send());
+    assert_eq!(body, "method: POST\nbody: hello");
+}
+
+#[test]
 fn test_redirect_get() {
     setup();
     let body = get_body(tinyget::get(url("/redirect")).send());


### PR DESCRIPTION
## Summary
- add tinyget::post(url) for POST requests
- add Request::with_method(...) and Request::with_body(...)
- automatically send Content-Length for non-empty request bodies unless already provided
- add a local POST integration test
- document POST usage in README and crate docs

Addresses the POST support part of #14. Certificate verification behavior is unchanged.

## Verification
- cargo fmt -- --check
- cargo clippy -- -D warnings
- cargo test
- cargo test --features timeout
- cargo test --features https
- cargo test --all-features
- cargo build --release
- cargo build --release --features https