### PR TITLE
Add dangerous TLS verification options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,18 @@ To enable HTTPS support, add the `https` feature:
 tinyget = { version = "1.1", features = ["https"] }
 ```
 
+For controlled test environments with invalid certificates, HTTPS requests can opt
+out of certificate or hostname validation:
+
+```rust
+let response = tinyget::get("https://self-signed.badssl.com/")
+    .danger_accept_invalid_certs(true)
+    .danger_accept_invalid_hostnames(true)
+    .send()?;
+```
+
+These options are dangerous and should not be used in production.
+
 ### Timeout Support
 
 To enable timeout support, add the `timeout` feature:

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -100,12 +100,10 @@ impl Connection {
         // parse_url in response.rs ensures that there is always a
         // ":port" in the host, which is why this unwrap is safe.
         let dns_name = dns_name.split(':').next().unwrap();
-        /*
         let mut builder = TlsConnector::builder();
-        ...
+        builder.danger_accept_invalid_certs(self.request.danger_accept_invalid_certs);
+        builder.danger_accept_invalid_hostnames(self.request.danger_accept_invalid_hostnames);
         let sess = match builder.build() {
-        */
-        let sess = match TlsConnector::new() {
             Ok(sess) => sess,
             Err(err) => return Err(Error::IoError(io::Error::new(io::ErrorKind::Other, err))),
         };
@@ -137,12 +135,10 @@ impl Connection {
         // parse_url in response.rs ensures that there is always a
         // ":port" in the host, which is why this unwrap is safe.
         let dns_name = dns_name.split(':').next().unwrap();
-        /*
         let mut builder = TlsConnector::builder();
-        ...
+        builder.danger_accept_invalid_certs(self.request.danger_accept_invalid_certs);
+        builder.danger_accept_invalid_hostnames(self.request.danger_accept_invalid_hostnames);
         let sess = match builder.build() {
-        */
-        let sess = match TlsConnector::new() {
             Ok(sess) => sess,
             Err(err) => return Err(Error::IoError(io::Error::new(io::ErrorKind::Other, err))),
         };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,13 @@
 //! [`Request`](struct.Request.html) and
 //! [`Response`](struct.Response.html) expose
 //!
+//! In controlled test environments, HTTPS requests can opt out of
+//! certificate or hostname validation using
+//! [`danger_accept_invalid_certs`](struct.Request.html#method.danger_accept_invalid_certs)
+//! and
+//! [`danger_accept_invalid_hostnames`](struct.Request.html#method.danger_accept_invalid_hostnames).
+//! These options are dangerous and should not be used in production.
+//!
 //! ## `timeout`
 //!
 //! This feature adds the ability to set a timeout for the request.

--- a/src/request.rs
+++ b/src/request.rs
@@ -33,6 +33,10 @@ pub struct Request {
     pub(crate) timeout: Option<u64>,
     max_redirects: usize,
     https: bool,
+    #[cfg(feature = "https")]
+    pub(crate) danger_accept_invalid_certs: bool,
+    #[cfg(feature = "https")]
+    pub(crate) danger_accept_invalid_hostnames: bool,
     pub(crate) redirects: Vec<(bool, URL, URL)>,
 }
 
@@ -54,6 +58,10 @@ impl Request {
             timeout: None,
             max_redirects: 100,
             https,
+            #[cfg(feature = "https")]
+            danger_accept_invalid_certs: false,
+            #[cfg(feature = "https")]
+            danger_accept_invalid_hostnames: false,
             redirects: Vec::new(),
         }
     }
@@ -99,6 +107,26 @@ impl Request {
     /// becomes a problem, please open an issue.
     pub fn with_max_redirects(mut self, max_redirects: usize) -> Request {
         self.max_redirects = max_redirects;
+        self
+    }
+
+    /// Controls whether invalid TLS certificates are accepted.
+    ///
+    /// This disables certificate chain validation and should only be
+    /// used for testing or other controlled environments.
+    #[cfg(feature = "https")]
+    pub fn danger_accept_invalid_certs(mut self, accept_invalid_certs: bool) -> Request {
+        self.danger_accept_invalid_certs = accept_invalid_certs;
+        self
+    }
+
+    /// Controls whether invalid TLS hostnames are accepted.
+    ///
+    /// This disables certificate hostname validation and should only be
+    /// used for testing or other controlled environments.
+    #[cfg(feature = "https")]
+    pub fn danger_accept_invalid_hostnames(mut self, accept_invalid_hostnames: bool) -> Request {
+        self.danger_accept_invalid_hostnames = accept_invalid_hostnames;
         self
     }
 
@@ -343,4 +371,19 @@ pub fn get<T: Into<URL>>(url: T) -> Request {
 /// Creates a POST request.
 pub fn post<T: Into<URL>>(url: T) -> Request {
     Request::new(url).with_method("POST")
+}
+
+#[cfg(all(test, feature = "https"))]
+mod tests {
+    use super::Request;
+
+    #[test]
+    fn stores_dangerous_tls_options() {
+        let request = Request::new("https://example.com")
+            .danger_accept_invalid_certs(true)
+            .danger_accept_invalid_hostnames(true);
+
+        assert!(request.danger_accept_invalid_certs);
+        assert!(request.danger_accept_invalid_hostnames);
+    }
 }


### PR DESCRIPTION
## Summary
- add Request::danger_accept_invalid_certs(...) for certificate-chain validation opt-out
- add Request::danger_accept_invalid_hostnames(...) for hostname validation opt-out
- wire both options through native-tls TlsConnector::builder()
- document that these options are dangerous and intended only for controlled environments

Fixes #14

## Verification
- cargo fmt -- --check
- cargo clippy -- -D warnings
- cargo test
- cargo test --features https
- cargo test --features timeout
- cargo test --all-features
- cargo build --release
- cargo build --release --features https